### PR TITLE
[iOS][#40] 로드한 데이터를 각 뷰에 바인딩하였습니다.

### DIFF
--- a/iOS/Todo/Todo.xcodeproj/project.pbxproj
+++ b/iOS/Todo/Todo.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		5A838E51243D9D0A0081A42F /* CardListsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E50243D9D0A0081A42F /* CardListsUseCase.swift */; };
 		5A838E54243DB4110081A42F /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E53243DB4110081A42F /* Response.swift */; };
 		5A838E59243DC8AF0081A42F /* JsonData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E58243DC8AF0081A42F /* JsonData.swift */; };
+		5A838E5C243DEBAE0081A42F /* TitleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E5B243DEBAE0081A42F /* TitleViewModel.swift */; };
+		5A838E5E243DF0470081A42F /* TitleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E5D243DF0470081A42F /* TitleModel.swift */; };
 		5A874634243C1D4E00FD1751 /* CardListTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A874633243C1D4E00FD1751 /* CardListTable.swift */; };
 		5A87463C243C1F2900FD1751 /* CardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A87463B243C1F2900FD1751 /* CardCell.swift */; };
 		5A87463F243C2C8C00FD1751 /* CardListTableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A87463E243C2C8C00FD1751 /* CardListTableDataSource.swift */; };
@@ -52,6 +54,8 @@
 		5A838E50243D9D0A0081A42F /* CardListsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListsUseCase.swift; sourceTree = "<group>"; };
 		5A838E53243DB4110081A42F /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
 		5A838E58243DC8AF0081A42F /* JsonData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonData.swift; sourceTree = "<group>"; };
+		5A838E5B243DEBAE0081A42F /* TitleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleViewModel.swift; sourceTree = "<group>"; };
+		5A838E5D243DF0470081A42F /* TitleModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleModel.swift; sourceTree = "<group>"; };
 		5A874633243C1D4E00FD1751 /* CardListTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListTable.swift; sourceTree = "<group>"; };
 		5A87463B243C1F2900FD1751 /* CardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCell.swift; sourceTree = "<group>"; };
 		5A87463E243C2C8C00FD1751 /* CardListTableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListTableDataSource.swift; sourceTree = "<group>"; };
@@ -126,11 +130,20 @@
 			path = JsonData;
 			sourceTree = "<group>";
 		};
+		5A838E5A243DEB950081A42F /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				5A838E5B243DEBAE0081A42F /* TitleViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
 		5A87463D243C2C6600FD1751 /* Models */ = {
 			isa = PBXGroup;
 			children = (
 				5A87463E243C2C8C00FD1751 /* CardListTableDataSource.swift */,
 				5A838E53243DB4110081A42F /* Response.swift */,
+				5A838E5D243DF0470081A42F /* TitleModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -171,6 +184,7 @@
 				5A838E4C243D66460081A42F /* Network */,
 				5A874644243C4C3900FD1751 /* Delegates */,
 				5A87463D243C2C6600FD1751 /* Models */,
+				5A838E5A243DEB950081A42F /* ViewModels */,
 				5AB8D58B243B5CBF00387EAE /* Views */,
 				5AB8D581243B4A5200387EAE /* ViewControllers */,
 				5AB8D551243B40FF00387EAE /* AppDelegate.swift */,
@@ -363,10 +377,12 @@
 				5AB8D552243B40FF00387EAE /* AppDelegate.swift in Sources */,
 				5A87463C243C1F2900FD1751 /* CardCell.swift in Sources */,
 				5A838E59243DC8AF0081A42F /* JsonData.swift in Sources */,
+				5A838E5C243DEBAE0081A42F /* TitleViewModel.swift in Sources */,
 				5A838E51243D9D0A0081A42F /* CardListsUseCase.swift in Sources */,
 				5A874646243C4C7B00FD1751 /* CardListTableDelegate.swift in Sources */,
 				5A874648243CAB5500FD1751 /* CardListScrollView.swift in Sources */,
 				5AB8D587243B54B600387EAE /* AcitivitiyLogController.swift in Sources */,
+				5A838E5E243DF0470081A42F /* TitleModel.swift in Sources */,
 				5AB8D585243B4FC700387EAE /* CardListController.swift in Sources */,
 				5AB8D554243B40FF00387EAE /* SceneDelegate.swift in Sources */,
 				5AB8D58D243B5CDC00387EAE /* TitleView.swift in Sources */,

--- a/iOS/Todo/Todo.xcodeproj/project.pbxproj
+++ b/iOS/Todo/Todo.xcodeproj/project.pbxproj
@@ -13,6 +13,10 @@
 		5A838E59243DC8AF0081A42F /* JsonData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E58243DC8AF0081A42F /* JsonData.swift */; };
 		5A838E5C243DEBAE0081A42F /* TitleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E5B243DEBAE0081A42F /* TitleViewModel.swift */; };
 		5A838E5E243DF0470081A42F /* TitleModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E5D243DF0470081A42F /* TitleModel.swift */; };
+		5A838E60243DFCE00081A42F /* CardViewModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E5F243DFCE00081A42F /* CardViewModels.swift */; };
+		5A838E62243DFD0E0081A42F /* CardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E61243DFD0E0081A42F /* CardViewModel.swift */; };
+		5A838E64243DFD530081A42F /* ViewModelBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E63243DFD530081A42F /* ViewModelBinding.swift */; };
+		5A838E68243DFDCA0081A42F /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E67243DFDCA0081A42F /* Card.swift */; };
 		5A874634243C1D4E00FD1751 /* CardListTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A874633243C1D4E00FD1751 /* CardListTable.swift */; };
 		5A87463C243C1F2900FD1751 /* CardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A87463B243C1F2900FD1751 /* CardCell.swift */; };
 		5A87463F243C2C8C00FD1751 /* CardListTableDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A87463E243C2C8C00FD1751 /* CardListTableDataSource.swift */; };
@@ -56,6 +60,10 @@
 		5A838E58243DC8AF0081A42F /* JsonData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JsonData.swift; sourceTree = "<group>"; };
 		5A838E5B243DEBAE0081A42F /* TitleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleViewModel.swift; sourceTree = "<group>"; };
 		5A838E5D243DF0470081A42F /* TitleModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleModel.swift; sourceTree = "<group>"; };
+		5A838E5F243DFCE00081A42F /* CardViewModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewModels.swift; sourceTree = "<group>"; };
+		5A838E61243DFD0E0081A42F /* CardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewModel.swift; sourceTree = "<group>"; };
+		5A838E63243DFD530081A42F /* ViewModelBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelBinding.swift; sourceTree = "<group>"; };
+		5A838E67243DFDCA0081A42F /* Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Card.swift; sourceTree = "<group>"; };
 		5A874633243C1D4E00FD1751 /* CardListTable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListTable.swift; sourceTree = "<group>"; };
 		5A87463B243C1F2900FD1751 /* CardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardCell.swift; sourceTree = "<group>"; };
 		5A87463E243C2C8C00FD1751 /* CardListTableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListTableDataSource.swift; sourceTree = "<group>"; };
@@ -133,7 +141,10 @@
 		5A838E5A243DEB950081A42F /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				5A838E63243DFD530081A42F /* ViewModelBinding.swift */,
 				5A838E5B243DEBAE0081A42F /* TitleViewModel.swift */,
+				5A838E61243DFD0E0081A42F /* CardViewModel.swift */,
+				5A838E5F243DFCE00081A42F /* CardViewModels.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -144,6 +155,7 @@
 				5A87463E243C2C8C00FD1751 /* CardListTableDataSource.swift */,
 				5A838E53243DB4110081A42F /* Response.swift */,
 				5A838E5D243DF0470081A42F /* TitleModel.swift */,
+				5A838E67243DFDCA0081A42F /* Card.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -372,20 +384,24 @@
 				5A874634243C1D4E00FD1751 /* CardListTable.swift in Sources */,
 				5A874641243C2D3300FD1751 /* ReusableView.swift in Sources */,
 				5A838E4E243D66620081A42F /* NetworkManager.swift in Sources */,
+				5A838E62243DFD0E0081A42F /* CardViewModel.swift in Sources */,
 				5A838E54243DB4110081A42F /* Response.swift in Sources */,
 				5AB8D556243B40FF00387EAE /* MainViewController.swift in Sources */,
 				5AB8D552243B40FF00387EAE /* AppDelegate.swift in Sources */,
+				5A838E60243DFCE00081A42F /* CardViewModels.swift in Sources */,
 				5A87463C243C1F2900FD1751 /* CardCell.swift in Sources */,
 				5A838E59243DC8AF0081A42F /* JsonData.swift in Sources */,
 				5A838E5C243DEBAE0081A42F /* TitleViewModel.swift in Sources */,
 				5A838E51243D9D0A0081A42F /* CardListsUseCase.swift in Sources */,
 				5A874646243C4C7B00FD1751 /* CardListTableDelegate.swift in Sources */,
 				5A874648243CAB5500FD1751 /* CardListScrollView.swift in Sources */,
+				5A838E64243DFD530081A42F /* ViewModelBinding.swift in Sources */,
 				5AB8D587243B54B600387EAE /* AcitivitiyLogController.swift in Sources */,
 				5A838E5E243DF0470081A42F /* TitleModel.swift in Sources */,
 				5AB8D585243B4FC700387EAE /* CardListController.swift in Sources */,
 				5AB8D554243B40FF00387EAE /* SceneDelegate.swift in Sources */,
 				5AB8D58D243B5CDC00387EAE /* TitleView.swift in Sources */,
+				5A838E68243DFDCA0081A42F /* Card.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/Todo/Todo/Models/Card.swift
+++ b/iOS/Todo/Todo/Models/Card.swift
@@ -1,0 +1,9 @@
+//
+//  Card.swift
+//  Todo
+//
+//  Created by kimdo2297 on 2020/04/08.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation

--- a/iOS/Todo/Todo/Models/Card.swift
+++ b/iOS/Todo/Todo/Models/Card.swift
@@ -7,3 +7,9 @@
 //
 
 import Foundation
+
+struct Card: Codable {
+    var id: String?
+    var title: String?
+    var content: String
+}

--- a/iOS/Todo/Todo/Models/CardListTableDataSource.swift
+++ b/iOS/Todo/Todo/Models/CardListTableDataSource.swift
@@ -9,18 +9,24 @@
 import UIKit
 
 final class CardListTableDataSource: NSObject {
+    private let cardViewModels: CardViewModels
     
+    init(cardViewModels: CardViewModels) {
+        self.cardViewModels = cardViewModels
+    }
 }
 
 extension CardListTableDataSource: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
+        return cardViewModels.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cardCell = tableView.dequeueReusableCell(withIdentifier: CardCell.reuseIdentifier, for: indexPath) as? CardCell else {
             fatalError("Unable to Dequeue \(CardCell.reuseIdentifier)")
         }
+        let index = indexPath.row
+        cardViewModels.bind(at: index, cardCell: cardCell)
         return cardCell
     }
 }

--- a/iOS/Todo/Todo/Models/Response.swift
+++ b/iOS/Todo/Todo/Models/Response.swift
@@ -28,8 +28,8 @@ struct Log: Codable {
 
 struct Section: Codable {
     var id: String?
-    var title: String?
-    var cards: [Card]?
+    var title: String
+    var cards: [Card]
 }
 
 struct Card: Codable {

--- a/iOS/Todo/Todo/Models/Response.swift
+++ b/iOS/Todo/Todo/Models/Response.swift
@@ -32,11 +32,5 @@ struct Section: Codable {
     var cards: [Card]
 }
 
-struct Card: Codable {
-    var id: String?
-    var title: String?
-    var content: String?
-}
-
 
 

--- a/iOS/Todo/Todo/Models/TitleModel.swift
+++ b/iOS/Todo/Todo/Models/TitleModel.swift
@@ -1,0 +1,14 @@
+//
+//  TitleModel.swift
+//  Todo
+//
+//  Created by kimdo2297 on 2020/04/08.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation
+
+struct TitleModel {
+    var title: String
+    var cardsCount: Int
+}

--- a/iOS/Todo/Todo/ViewControllers/CardListController.swift
+++ b/iOS/Todo/Todo/ViewControllers/CardListController.swift
@@ -11,9 +11,9 @@ final class CardListController: UIViewController {
     //MARK:- internal property
     private let titleView = TitleView()
     private var titleViewModel: TitleViewModel!
-    private let cardListTable = CardListTable()
-    private let cardListTableDataSource = CardListTableDataSource()
-    private let cardListTableDelegate = CardListTableDelegate()
+    private var cardListTable = CardListTable()
+    private var cardListTableDataSource: CardListTableDataSource!
+    private var cardListTableDelegate = CardListTableDelegate()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -33,7 +33,6 @@ final class CardListController: UIViewController {
     
     private func configureTableView() {
         cardListTable.register(CardCell.self, forCellReuseIdentifier: CardCell.reuseIdentifier)
-        cardListTable.dataSource = cardListTableDataSource
         cardListTable.delegate = cardListTableDelegate
         configureTableConstraints()
     }
@@ -50,15 +49,8 @@ final class CardListController: UIViewController {
     
     var cardList: Section? {
         didSet {
-            processTitleViewModel()
-        }
-    }
-    
-    private func processTitleViewModel() {
-        if titleViewModel == nil {
             configureTitleViewModel()
-        } else {
-            updateTitleViewModel()
+            configureDataSource()
         }
     }
     
@@ -73,8 +65,11 @@ final class CardListController: UIViewController {
         })
     }
     
-    private func updateTitleViewModel() {
-        //...
+    private func configureDataSource() {
+        guard let cardList = cardList else { return }
+        let cardViewModels = cardList.cards.map { CardViewModel(card: $0) }
+        cardListTableDataSource = CardListTableDataSource(cardViewModels: CardViewModels(cardViewModels))
+        cardListTable.dataSource = cardListTableDataSource
     }
 }
 

--- a/iOS/Todo/Todo/ViewControllers/CardListController.swift
+++ b/iOS/Todo/Todo/ViewControllers/CardListController.swift
@@ -8,8 +8,9 @@
 
 import UIKit
 final class CardListController: UIViewController {
-    var cardList: Section?
+    //MARK:- internal property
     private let titleView = TitleView()
+    private var titleViewModel: TitleViewModel!
     private let cardListTable = CardListTable()
     private let cardListTableDataSource = CardListTableDataSource()
     private let cardListTableDelegate = CardListTableDelegate()
@@ -45,6 +46,35 @@ final class CardListController: UIViewController {
         cardListTable.widthAnchor.constraint(equalTo: safeArea.widthAnchor).isActive = true
         cardListTable.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor).isActive = true
         cardListTable.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor).isActive = true
+    }
+    
+    var cardList: Section? {
+        didSet {
+            processTitleViewModel()
+        }
+    }
+    
+    private func processTitleViewModel() {
+        if titleViewModel == nil {
+            configureTitleViewModel()
+        } else {
+            updateTitleViewModel()
+        }
+    }
+    
+    private func configureTitleViewModel() {
+        guard let cardList = cardList else { return }
+        titleViewModel = TitleViewModel(titleModel: TitleModel(title: cardList.title,
+                                                               cardsCount: cardList.cards.count),
+                                        changed: { titleModel in
+                                            guard let titleModel = titleModel else { return }
+                                                self.titleView.badge.text = String(titleModel.cardsCount)
+                                                self.titleView.titleLabel.text = titleModel.title
+        })
+    }
+    
+    private func updateTitleViewModel() {
+        //...
     }
 }
 

--- a/iOS/Todo/Todo/ViewModels/CardViewModel.swift
+++ b/iOS/Todo/Todo/ViewModels/CardViewModel.swift
@@ -1,0 +1,9 @@
+//
+//  CardViewModel.swift
+//  Todo
+//
+//  Created by kimdo2297 on 2020/04/08.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation

--- a/iOS/Todo/Todo/ViewModels/CardViewModel.swift
+++ b/iOS/Todo/Todo/ViewModels/CardViewModel.swift
@@ -7,3 +7,29 @@
 //
 
 import Foundation
+
+final class CardViewModel: ViewModelBinding {
+    typealias Key = Card?
+    private var card: Key = nil {
+        didSet {
+            changedHandler(card)
+        }
+    }
+    private var changedHandler : (Key) -> ()
+    
+    init(card: Card, changed handler: @escaping (Key) -> () = { _ in }) {
+        self.changedHandler = handler
+        self.card = card
+        changedHandler(card)
+    }
+    
+    func bind(_ cardCell: CardCell) {
+        guard let card = card else { return }
+        cardCell.titleLabel.text = card.title
+        cardCell.contentLabel.text = card.content
+    }
+    
+    func updateNotify(changed handler: @escaping (Card?) -> ()) {
+        self.changedHandler = handler
+    }
+}

--- a/iOS/Todo/Todo/ViewModels/CardViewModels.swift
+++ b/iOS/Todo/Todo/ViewModels/CardViewModels.swift
@@ -7,3 +7,20 @@
 //
 
 import Foundation
+
+final class CardViewModels {
+    private let cardViewModels: [CardViewModel]
+    
+    init(_ cardViewModels: [CardViewModel]) {
+        self.cardViewModels = cardViewModels
+    }
+    
+    func bind(at index: Int, cardCell: CardCell) {
+        guard index < cardViewModels.count else { return }
+        cardViewModels[index].bind(cardCell)
+    }
+
+    var count: Int {
+        return cardViewModels.count
+    }
+}

--- a/iOS/Todo/Todo/ViewModels/CardViewModels.swift
+++ b/iOS/Todo/Todo/ViewModels/CardViewModels.swift
@@ -1,0 +1,9 @@
+//
+//  CardViewModels.swift
+//  Todo
+//
+//  Created by kimdo2297 on 2020/04/08.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation

--- a/iOS/Todo/Todo/ViewModels/TitleViewModel.swift
+++ b/iOS/Todo/Todo/ViewModels/TitleViewModel.swift
@@ -8,11 +8,6 @@
 
 import Foundation
 
-protocol ViewModelBinding {
-    associatedtype Key
-    func updateNotify(changed handler: @escaping (Key) -> ())
-}
-
 final class TitleViewModel: ViewModelBinding {
     typealias Key = TitleModel?
     private var titleModel : Key = nil {

--- a/iOS/Todo/Todo/ViewModels/TitleViewModel.swift
+++ b/iOS/Todo/Todo/ViewModels/TitleViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  TitleViewModel.swift
+//  Todo
+//
+//  Created by kimdo2297 on 2020/04/08.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation
+
+protocol ViewModelBinding {
+    associatedtype Key
+    func updateNotify(changed handler: @escaping (Key) -> ())
+}
+
+final class TitleViewModel: ViewModelBinding {
+    typealias Key = TitleModel?
+    private var titleModel : Key = nil {
+        didSet {
+            changedHandler(titleModel)
+        }
+    }
+    private var changedHandler : (Key) -> ()
+    
+    init(titleModel: TitleModel, changed handler: @escaping (Key) -> () = { _ in }) {
+        self.changedHandler = handler
+        self.titleModel = titleModel
+        handler(titleModel)
+    }
+    
+    func updateNotify(changed handler: @escaping (TitleModel?) -> ()) {
+        self.changedHandler = handler
+    }
+}
+

--- a/iOS/Todo/Todo/ViewModels/ViewModelBinding.swift
+++ b/iOS/Todo/Todo/ViewModels/ViewModelBinding.swift
@@ -1,0 +1,9 @@
+//
+//  ViewModelBinding.swift
+//  Todo
+//
+//  Created by kimdo2297 on 2020/04/08.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation

--- a/iOS/Todo/Todo/ViewModels/ViewModelBinding.swift
+++ b/iOS/Todo/Todo/ViewModels/ViewModelBinding.swift
@@ -7,3 +7,8 @@
 //
 
 import Foundation
+
+protocol ViewModelBinding {
+    associatedtype Key
+    func updateNotify(changed handler: @escaping (Key) -> ())
+}

--- a/iOS/Todo/Todo/Views/CardCell.swift
+++ b/iOS/Todo/Todo/Views/CardCell.swift
@@ -106,11 +106,6 @@ final class CardTitleLabel: UILabel {
     
     private func configure() {
         translatesAutoresizingMaskIntoConstraints = false
-        confugureText()
-    }
-    
-    private func confugureText() {
-        text = "Github 공부하기"
         font = UIFont.boldSystemFont(ofSize: 15)
     }
 }
@@ -128,13 +123,8 @@ final class ContentLabel: UILabel {
     
     private func configure() {
         translatesAutoresizingMaskIntoConstraints = false
-        configureText()
-    }
-    
-    private func configureText() {
         lineBreakMode = .byWordWrapping
         numberOfLines = 3
-        text = "contextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextcontextUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimensionUITableView.automaticDimension"
     }
 }
 
@@ -151,10 +141,6 @@ final class AuthorLabel: UILabel {
     
     private func configure() {
         translatesAutoresizingMaskIntoConstraints = false
-        configureText()
-    }
-    
-    private func configureText() {
         text = "author By iOS"
         font = UIFont.boldSystemFont(ofSize: 12)
     }

--- a/iOS/Todo/Todo/Views/CardCell.swift
+++ b/iOS/Todo/Todo/Views/CardCell.swift
@@ -42,7 +42,7 @@ final class CardCell: UITableViewCell, ReusableView {
     private func configureFormatImageView() {
         contentView.addSubview(formatImageView)
         
-        let constant: CGFloat = 8
+        let constant: CGFloat = 10
         formatImageView.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: constant).isActive = true
         formatImageView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor, constant: constant).isActive = true
     }
@@ -50,7 +50,7 @@ final class CardCell: UITableViewCell, ReusableView {
     private func configureTitle() {
         contentView.addSubview(titleLabel)
         
-        let constant: CGFloat = 8
+        let constant: CGFloat = 10
         titleLabel.topAnchor.constraint(equalTo: self.contentView.topAnchor, constant: constant).isActive = true
         titleLabel.leadingAnchor.constraint(equalTo: formatImageView.trailingAnchor, constant: constant).isActive = true
         titleLabel.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -constant).isActive = true
@@ -59,7 +59,7 @@ final class CardCell: UITableViewCell, ReusableView {
     private func configureContext() {
         contentView.addSubview(contentLabel)
         
-        let constant: CGFloat = 8
+        let constant: CGFloat = 10
         contentLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: constant).isActive = true
         contentLabel.leadingAnchor.constraint(equalTo: formatImageView.trailingAnchor, constant: constant).isActive = true
         contentLabel.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -constant).isActive = true
@@ -68,7 +68,7 @@ final class CardCell: UITableViewCell, ReusableView {
     private func configureDetailText() {
         contentView.addSubview(authorLabel)
         
-        let constant: CGFloat = 8
+        let constant: CGFloat = 10
         authorLabel.topAnchor.constraint(equalTo: contentLabel.bottomAnchor, constant: constant).isActive = true
         authorLabel.leadingAnchor.constraint(equalTo: formatImageView.trailingAnchor, constant:  constant).isActive = true
         authorLabel.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor, constant: -constant).isActive = true
@@ -89,6 +89,8 @@ final class FormatImageView: UIImageView {
     
     private func configure() {
         translatesAutoresizingMaskIntoConstraints = false
+        heightAnchor.constraint(equalToConstant: 25).isActive = true
+        widthAnchor.constraint(equalTo: heightAnchor, multiplier: 1).isActive = true
         image = UIImage(systemName: "text.justify")!
     }
 }

--- a/iOS/Todo/Todo/Views/TitleView.swift
+++ b/iOS/Todo/Todo/Views/TitleView.swift
@@ -121,10 +121,6 @@ final class TitleLabel: UILabel {
     
     private func configure() {
         translatesAutoresizingMaskIntoConstraints = false
-        configureText()
-    }
-    
-    private func configureText() {
         font = UIFont.boldSystemFont(ofSize: 20)
     }
 }


### PR DESCRIPTION
이슈 #40 을 해결하였습니다.

> 한 것

* jk가 올려준 뷰모델에 대한 gist 코드를 참고하여 뷰모델을 만들었습니다.
  * 프로토콜 ViewModelBinding을  만들어 각 뷰모델에 채택했습니다. 
    * 하지만 제가 이해한 바로는 실제 타입으로 각 변수들을 선언해서 `의존성 역전`을 하지 못한 것 같습니다.

> 고민한 점 

* 상황에 따라 다르게 바인딩하였습니다.
  1.  TitleViewModel은 생성되자마자 핸들러를 통해 타이틀 뷰에 데이터를 바인딩하도록 기능 구현하였습니다. 
  2. CardViewModels, CardViewModel은 TableView, CardCell와 관련이 있어서 데이터 소스 객체에 주입하도록 하였고 데이터 소스 객체가 메소드 `tableView(cellForRowAt: )`를 호출할때 메소드 내부에서 CardViewModel의 데이터가 CardCell로 바인딩되도록 기능 구현하였습니다.

=> 혹시 제가 뷰에 데이터를 바인딩하는 방식이 적절하지 못한다면 알려주시면 감사하겠습니다. 

> 하지 못한 것

* 처음 데이터를 로드한 경우만 생각했지, 이후 데이터들이 업데이트되는 상황에서 뷰에 데이터를 바인딩하는 것은 고려하지 못하였습니다. 상당한 난항을 겪을꺼라 예상되는데, 내일 아침부터 이슈를 만들어 시도하려고 합니다!