### PR TITLE
[#115] refactor: 요청, 응답 데이터에 cardIndex 제거

### DIFF
--- a/BE/README.md
+++ b/BE/README.md
@@ -64,8 +64,7 @@ http://ec2-15-164-63-83.ap-northeast-2.compute.amazonaws.com:8080
                     "content": "구현 API 내용 작성",
                     "createDateTime": "2020-04-15 03:12:32",
                     "updateDateTime": "2020-04-15 03:13:00",
-                    "author": "nigayo",
-                    "cardIndex": 0
+                    "author": "nigayo"
                 }
             ]
         },
@@ -124,8 +123,7 @@ http://ec2-15-164-63-83.ap-northeast-2.compute.amazonaws.com:8080
             "content": "회고하자",
             "createDateTime": "2020-04-14T15:44:19",
             "updateDateTime": "2020-04-14T15:44:19",
-            "author": "nigayo",
-            "cardIndex": 1
+            "author": "nigayo"
         }
     }
 }
@@ -138,13 +136,12 @@ http://ec2-15-164-63-83.ap-northeast-2.compute.amazonaws.com:8080
 ### 요청 데이터
 ```
 {
-    "cardIndex": 1,
     "title": "README.md 추가 안함",
     "content": "구현 API 내용 작성 안함",
 }
 ```
 - 카드 수정 요청 시, URL에 sectionId와 cardId를 전달해야 합니다.
-- Body에는 카드 객체 생성 시 반환받은 cardIndex와 변경하고자 하는 데이터(title, content)를 함께 보냅니다.
+- Body에는 변경하고자 하는 데이터(title, content)를 함께 보냅니다.
 - 프론트에서는 content에 변경될 카드 내용을 담아주세요.
 
 ### JSON 응답
@@ -163,8 +160,7 @@ http://ec2-15-164-63-83.ap-northeast-2.compute.amazonaws.com:8080
             "content": "구현 API 내용 작성 안함",
             "createDateTime": "2020-04-15 03:12:32",
             "updateDateTime": "2020-04-15 03:13:00",
-            "author": "nigayo",
-            "cardIndex": 1
+            "author": "nigayo"
         }
     }
 }

--- a/BE/src/main/java/com/codesquad/team10/todo/api/CardController.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/api/CardController.java
@@ -62,21 +62,21 @@ public class CardController {
     }
 
     @PatchMapping("/{cardId}")
-    public ResponseEntity<ResponseData> update(@PathVariable int sectionId, @PathVariable int cardId, @RequestBody CardDTO card) {
-        if (card.getCardIndex() == null)
+    public ResponseEntity<ResponseData> update(@PathVariable int sectionId, @PathVariable int cardId, @RequestBody CardDTO updateCard) {
+        if (updateCard.getContent() == null)
             throw new InvalidRequestException();
-
+        Card targetCard = cardRepository.findById(cardId).orElseThrow(ResourceNotFoundException::new);
         Section section = sectionRepository.findById(sectionId).orElseThrow(ResourceNotFoundException::new);
-        CardDTO resultCard = null;
         Map<String, Object> responseData = null;
         try {
             // 카드 내용 수정
-            section.updateCard((Card)ModelMapper.of(card));
+            targetCard.setTitle(updateCard.getTitle());
+            targetCard.setContent(updateCard.getContent());
+            section.updateCard(targetCard);
             sectionRepository.save(section);
-            // updateCreateTime 반영된 시간 받아오기 위해서 레포지토리에서 Get
-            resultCard = (CardDTO)ModelMapper.of(cardRepository.findById(cardId).orElseThrow(ResourceNotFoundException::new));
+            CardDTO resultCard = (CardDTO)ModelMapper.of(targetCard);
             // 로그 추가
-            Log log = new Log(TEST_USER_NAME, Action.UPDATED, Target.CARD, substractTarget(card.getTitle() ,card.getContent()), null, null, TEST_BOARD_ID);
+            Log log = new Log(TEST_USER_NAME, Action.UPDATED, Target.CARD, substractTarget(targetCard.getTitle() ,targetCard.getContent()), null, null, TEST_BOARD_ID);
             logRepository.save(log);
             logger.debug("log: {}", log);
             //반환 데이터

--- a/BE/src/main/java/com/codesquad/team10/todo/entity/Card.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/entity/Card.java
@@ -46,8 +46,16 @@ public class Card {
         return title;
     }
 
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
     public String getContent() {
         return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
     }
 
     public LocalDateTime getCreateDateTime() {

--- a/BE/src/main/java/com/codesquad/team10/todo/entity/Card.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/entity/Card.java
@@ -1,5 +1,6 @@
 package com.codesquad.team10.todo.entity;
 
+import com.codesquad.team10.todo.vo.CardDTO;
 import org.springframework.data.annotation.Id;
 
 import java.time.LocalDateTime;
@@ -25,6 +26,15 @@ public class Card {
     private Integer user;
 
     private Integer sectionKey;
+
+    public Card() {}
+
+    public Card(String title, String content, String author, Integer user) {
+        this.title = title;
+        this.content = content;
+        this.author = author;
+        this.user = user;
+    }
 
     public Card(Integer id, String title, String content, LocalDateTime createDateTime, LocalDateTime updateDateTime, String author, boolean deleted, Integer user, Integer sectionKey) {
         this.id = id;
@@ -90,10 +100,11 @@ public class Card {
         return sectionKey;
     }
 
-    public void update(Card updatedCard) {
-        this.title = updatedCard.title;
-        this.content = updatedCard.content;
+    public Card update(String title, String content) {
+        this.title = title;
+        this.content = content;
         this.updateDateTime = LocalDateTime.now();
+        return this;
     }
 
     @Override

--- a/BE/src/main/java/com/codesquad/team10/todo/entity/Section.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/entity/Section.java
@@ -1,6 +1,7 @@
 package com.codesquad.team10.todo.entity;
 
 import com.codesquad.team10.todo.exception.custom.UnmatchedRequestDataException;
+import com.codesquad.team10.todo.vo.CardDTO;
 import org.springframework.data.annotation.Id;
 
 import java.time.LocalDateTime;
@@ -69,14 +70,19 @@ public class Section {
         cards.add(newCard);
     }
 
-    public void updateCard(Card updateCard) {
-        cards.get(updateCard.getSectionKey()).update(updateCard);
+    public Card updateCard(Card updateCard, String title, String content) {
+        Card target = cards.get(updateCard.getSectionKey());
+        if (!target.equals(updateCard))
+            throw new UnmatchedRequestDataException();
+
+        return target.update(title, content);
     }
 
     public void deleteCard(Card deleteCard) {
         Card target = cards.get(deleteCard.getSectionKey());
         if (!target.equals(deleteCard))
             throw new UnmatchedRequestDataException();
+
         cards.remove(target);
     }
 

--- a/BE/src/main/java/com/codesquad/team10/todo/entity/Section.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/entity/Section.java
@@ -1,6 +1,5 @@
 package com.codesquad.team10.todo.entity;
 
-import com.codesquad.team10.todo.exception.custom.InvalidRequestException;
 import com.codesquad.team10.todo.exception.custom.UnmatchedRequestDataException;
 import org.springframework.data.annotation.Id;
 
@@ -70,13 +69,13 @@ public class Section {
         cards.add(newCard);
     }
 
-    public void updateCard(Card updatedCard) {
-        cards.get(updatedCard.getSectionKey()).update(updatedCard);
+    public void updateCard(Card updateCard) {
+        cards.get(updateCard.getSectionKey()).update(updateCard);
     }
 
-    public void deleteCard(Card deletedCard) {
-        Card target = cards.get(deletedCard.getSectionKey());
-        if (!target.equals(deletedCard))
+    public void deleteCard(Card deleteCard) {
+        Card target = cards.get(deleteCard.getSectionKey());
+        if (!target.equals(deleteCard))
             throw new UnmatchedRequestDataException();
         cards.remove(target);
     }

--- a/BE/src/main/java/com/codesquad/team10/todo/util/ModelMapper.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/util/ModelMapper.java
@@ -38,7 +38,7 @@ public class ModelMapper {
                         cardDTO.getAuthor(),
                         cardDTO.isDeleted(),
                         cardDTO.getUser(),
-                        cardDTO.getCardIndex()
+                        cardDTO.getSectionKey()
                 );
             case "Section":
                 Section section = (Section)object;

--- a/BE/src/main/java/com/codesquad/team10/todo/vo/CardDTO.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/vo/CardDTO.java
@@ -83,4 +83,8 @@ public class CardDTO {
     public Integer getSectionKey() {
         return sectionKey;
     }
+
+    public void setSectionKey(Integer sectionKey) {
+        this.sectionKey = sectionKey;
+    }
 }

--- a/BE/src/main/java/com/codesquad/team10/todo/vo/CardDTO.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/vo/CardDTO.java
@@ -25,9 +25,10 @@ public class CardDTO {
     @JsonIgnore
     private Integer user;
 
-    private Integer cardIndex;
+    @JsonIgnore
+    private Integer sectionKey;
 
-    public CardDTO(Integer id, String title, String content, LocalDateTime createDateTime, LocalDateTime updateDateTime, String author, boolean deleted, Integer user, Integer cardIndex) {
+    public CardDTO(Integer id, String title, String content, LocalDateTime createDateTime, LocalDateTime updateDateTime, String author, boolean deleted, Integer user, Integer sectionKey) {
         this.id = id;
         this.title = title;
         this.content = content;
@@ -36,7 +37,7 @@ public class CardDTO {
         this.author = author;
         this.deleted = deleted;
         this.user = user;
-        this.cardIndex = cardIndex;
+        this.sectionKey = sectionKey;
     }
 
     public Integer getId() {
@@ -79,11 +80,7 @@ public class CardDTO {
         return user;
     }
 
-    public Integer getCardIndex() {
-        return cardIndex;
-    }
-
-    public void setCardIndex(Integer cardIndex) {
-        this.cardIndex = cardIndex;
+    public Integer getSectionKey() {
+        return sectionKey;
     }
 }


### PR DESCRIPTION
Closed #115
- 카드 레포지토리를 사용하기 때문에 cardIndex는 필요가 없으며, 클라이언트에서 핸들링한 카드 인덱스 값을 이용하는 것은 DB와 달라질 위험이 있으므로 (쿼리문 요청이 1개 더 발생하더라도) id로 처리하도록 협의했습니다.