### PR TITLE
[BE][#115][#116] 카드 cardIndex 데이터를 요청 및 응답에서 제거, 로그 시간 데이터 변경, 로그 title, content 구분

### DIFF
--- a/BE/README.md
+++ b/BE/README.md
@@ -248,20 +248,22 @@ http://ec2-15-164-63-83.ap-northeast-2.compute.amazonaws.com:8080
             "user": "nigayo",
             "action": "ADDED",
             "target": "CARD",
+            "title": null,
             "content": "과자 사기",
             "source": null,
             "destination": "해야할 일",
-            "minutesUntilNow": 2
+            "createDateTime": "2020-04-15 16:15:11"
         },
         {
             "id": 2,
             "user": "nigayo",
             "action": "UPDATED",
             "target": "CARD",
+            "title": null,
             "content": "음료 사기",
             "source": null,
             "destination": null,
-            "minutesUntilNow": 0
+            "createDateTime": "2020-04-15 16:15:41"
         }
     ]
 }

--- a/BE/README.md
+++ b/BE/README.md
@@ -121,8 +121,8 @@ http://ec2-15-164-63-83.ap-northeast-2.compute.amazonaws.com:8080
             "id": 2,
             "title": "회고",
             "content": "회고하자",
-            "createDateTime": "2020-04-14T15:44:19",
-            "updateDateTime": "2020-04-14T15:44:19",
+            "createDateTime": "2020-04-15 03:12:32",
+            "updateDateTime": "2020-04-15 03:12:32",
             "author": "nigayo"
         }
     }

--- a/BE/src/main/java/com/codesquad/team10/todo/api/CardController.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/api/CardController.java
@@ -54,7 +54,7 @@ public class CardController {
         CardDTO cardDTO = null;
         cardDTO = (CardDTO) ModelMapper.of(newCard);
         // 로그 추가
-        Log log = new Log(TEST_USER_NAME, Action.ADDED, Target.CARD, substractTarget(cardDTO.getTitle(), cardDTO.getContent()), null, section.getTitle(), TEST_BOARD_ID);
+        Log log = new Log(TEST_USER_NAME, Action.ADDED, Target.CARD, newCard.getTitle(), newCard.getContent(), null, section.getTitle(), TEST_BOARD_ID);
         logRepository.save(log);
         // 반환 데이터
         return new ResponseEntity<>(new ResponseData(ResponseData.Status.SUCCESS, constructResonseData(cardDTO, log, section.getCards().size())), HttpStatus.OK);
@@ -74,7 +74,7 @@ public class CardController {
         CardDTO resultCard = (CardDTO) ModelMapper.of(section.updateCard(updateCard, body.get("title"), body.get("content")));
         sectionRepository.save(section);
         // 로그 추가
-        Log log = new Log(TEST_USER_NAME, Action.UPDATED, Target.CARD, substractTarget(resultCard.getTitle(), resultCard.getContent()), null, null, TEST_BOARD_ID);
+        Log log = new Log(TEST_USER_NAME, Action.UPDATED, Target.CARD, resultCard.getTitle(), resultCard.getContent(), null, null, TEST_BOARD_ID);
         logRepository.save(log);
         logger.debug("log: {}", log);
         //반환 데이터
@@ -91,22 +91,11 @@ public class CardController {
 
         section.deleteCard(targetCard);
         sectionRepository.save(section);
-        Log log = new Log(TEST_USER_NAME, Action.REMOVED, Target.CARD, substractTarget(targetCard.getTitle(), targetCard.getContent()), section.getTitle(), null, TEST_BOARD_ID);
+        Log log = new Log(TEST_USER_NAME, Action.REMOVED, Target.CARD, targetCard.getTitle(), targetCard.getContent(), section.getTitle(), null, TEST_BOARD_ID);
         logRepository.save(log);
         logger.debug("log: {}", log);
         Map<String, Object> responseData = constructResonseData(log, section.getCards().size());
         return new ResponseEntity<>(new ResponseData(ResponseData.Status.SUCCESS, responseData), HttpStatus.OK);
-    }
-
-    private String substractTarget(String title, String content) {
-        if (title != null)
-            return title;
-
-        final String delimiter = "\r\n";
-        if (content.contains(delimiter))
-            return content.substring(0, content.indexOf(delimiter));
-
-        return content;
     }
 
     private Map<String, Object> constructResonseData(CardDTO cardDTO, Log log, int cardCount) {

--- a/BE/src/main/java/com/codesquad/team10/todo/entity/Log.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/entity/Log.java
@@ -15,6 +15,8 @@ public class Log {
 
     private Target target;
 
+    private String title;
+
     private String content;
 
     private String source;
@@ -28,21 +30,23 @@ public class Log {
     public Log() {
     }
 
-    public Log(String user, Action action, Target target, String content, String source, String destination, Integer board) {
+    public Log(String user, Action action, Target target, String title, String content, String source, String destination, Integer board) {
         this.user = user;
         this.action = action;
         this.target = target;
+        this.title = title;
         this.content = content;
         this.source = source;
         this.destination = destination;
         this.board = board;
     }
 
-    public Log(Integer id, String user, Action action, Target target, String content, String source, String destination, LocalDateTime createDateTime, Integer board) {
+    public Log(Integer id, String user, Action action, Target target, String title, String content, String source, String destination, LocalDateTime createDateTime, Integer board) {
         this.id = id;
         this.user = user;
         this.action = action;
         this.target = target;
+        this.title = title;
         this.content = content;
         this.source = source;
         this.destination = destination;
@@ -64,6 +68,10 @@ public class Log {
 
     public Target getTarget() {
         return target;
+    }
+
+    public String getTitle() {
+        return title;
     }
 
     public String getContent() {

--- a/BE/src/main/java/com/codesquad/team10/todo/util/ModelMapper.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/util/ModelMapper.java
@@ -57,6 +57,7 @@ public class ModelMapper {
                   log.getUser(),
                   log.getAction(),
                   log.getTarget(),
+                  log.getTitle(),
                   log.getContent(),
                   log.getSource(),
                   log.getDestination(),

--- a/BE/src/main/java/com/codesquad/team10/todo/vo/LogDTO.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/vo/LogDTO.java
@@ -2,6 +2,7 @@ package com.codesquad.team10.todo.vo;
 
 import com.codesquad.team10.todo.entity.Action;
 import com.codesquad.team10.todo.entity.Target;
+import com.codesquad.team10.todo.util.DateTimeFormatUtils;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -16,25 +17,28 @@ public class LogDTO {
 
     private Target target;
 
+    private String title;
+
     private String content;
 
     private String source;
 
     private String destination;
 
-    private long minutesUntilNow;
+    private LocalDateTime createDateTime;
 
     private Integer board;
 
-    public LogDTO(Integer id, String user, Action action, Target target, String content, String source, String destination, LocalDateTime createDateTime, Integer board) {
+    public LogDTO(Integer id, String user, Action action, Target target, String title, String content, String source, String destination, LocalDateTime createDateTime, Integer board) {
         this.id = id;
         this.user = user;
         this.action = action;
         this.target = target;
+        this.title = title;
         this.content = content;
         this.source = source;
         this.destination = destination;
-        this.minutesUntilNow = createDateTime.until(LocalDateTime.now(), ChronoUnit.MINUTES);
+        this.createDateTime = createDateTime;
         this.board = board;
     }
 
@@ -54,6 +58,10 @@ public class LogDTO {
         return target;
     }
 
+    public String getTitle() {
+        return title;
+    }
+
     public String getContent() {
         return content;
     }
@@ -66,7 +74,7 @@ public class LogDTO {
         return destination;
     }
 
-    public long getMinutesUntilNow() {
-        return minutesUntilNow;
+    public String getCreateDateTime() {
+        return DateTimeFormatUtils.localDateTimeToString(createDateTime);
     }
 }

--- a/BE/src/main/resources/schema.sql
+++ b/BE/src/main/resources/schema.sql
@@ -43,7 +43,8 @@ CREATE TABLE IF NOT EXISTS log (
   user varchar(64) ,
   action enum('ADDED', 'REMOVED', 'UPDATED', 'MOVED') ,
   target enum('SECTION', 'CARD') ,
-  content varchar(500) not null ,     /* source와 destination이 모두 null이면 target이 section이어야 한다. */
+  title varchar(100) ,
+  content varchar(500) ,     /* source와 destination이 모두 null이면 target이 section이어야 한다. */
   source varchar(100) ,    /* section */
   destination varchar(100) ,        /* section */
   create_date_time timestamp not null default current_timestamp ,


### PR DESCRIPTION
Closed #115 
Closed #116 

- 카드 관련 api에서 요청 및 응답 데이터에 존재했던 cardIndex를 제거합니다. (클라이언트와 상의)
- 로그 시간 데이터를 minutesUntilNow => createDateTime으로 변경하여 지난 시간은 클라이언트에서 처리합니다.
- 로그 데이터의 title, content 컬럼을 추가하여 데이터를 구분합니다. (클라이언트에서 구분)