### PR TITLE
[iOS][#91] MoveToDone, 드래그 앤 드랍 기능 구현하였습니다. 

### DIFF
--- a/iOS/Todo/Todo.xcodeproj/project.pbxproj
+++ b/iOS/Todo/Todo.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		5A7938202441B60D00D59611 /* ContentViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A79381F2441B60D00D59611 /* ContentViewDelegate.swift */; };
 		5A7938222441B84200D59611 /* TitleFieldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7938212441B84200D59611 /* TitleFieldDelegate.swift */; };
 		5A7938252441BBAA00D59611 /* Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7938242441BBAA00D59611 /* Controller.swift */; };
+		5A7A55B6244701A10041FC55 /* DragObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A7A55B5244701A10041FC55 /* DragObject.swift */; };
 		5A838E4E243D66620081A42F /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E4D243D66620081A42F /* NetworkManager.swift */; };
 		5A838E51243D9D0A0081A42F /* ColumnsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E50243D9D0A0081A42F /* ColumnsUseCase.swift */; };
 		5A838E54243DB4110081A42F /* ColumnsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A838E53243DB4110081A42F /* ColumnsResponse.swift */; };
@@ -88,6 +89,7 @@
 		5A79381F2441B60D00D59611 /* ContentViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewDelegate.swift; sourceTree = "<group>"; };
 		5A7938212441B84200D59611 /* TitleFieldDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleFieldDelegate.swift; sourceTree = "<group>"; };
 		5A7938242441BBAA00D59611 /* Controller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controller.swift; sourceTree = "<group>"; };
+		5A7A55B5244701A10041FC55 /* DragObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DragObject.swift; path = TodoTests/DragObject.swift; sourceTree = SOURCE_ROOT; };
 		5A838E4D243D66620081A42F /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		5A838E50243D9D0A0081A42F /* ColumnsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnsUseCase.swift; sourceTree = "<group>"; };
 		5A838E53243DB4110081A42F /* ColumnsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColumnsResponse.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 				5A7937F7243F1AFA00D59611 /* DeleteResponse.swift */,
 				5A838E5D243DF0470081A42F /* TitleModel.swift */,
 				5ADF26B824459E7B008C15CA /* NewCard.swift */,
+				5A7A55B5244701A10041FC55 /* DragObject.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -511,6 +514,7 @@
 				5AB8D587243B54B600387EAE /* AcitivitiyLogController.swift in Sources */,
 				5A7938252441BBAA00D59611 /* Controller.swift in Sources */,
 				5A838E5E243DF0470081A42F /* TitleModel.swift in Sources */,
+				5A7A55B6244701A10041FC55 /* DragObject.swift in Sources */,
 				5AB8D585243B4FC700387EAE /* ColumnViewController.swift in Sources */,
 				5AB8D554243B40FF00387EAE /* SceneDelegate.swift in Sources */,
 				5AB8D58D243B5CDC00387EAE /* TitleView.swift in Sources */,

--- a/iOS/Todo/Todo/Coder/ColumnsUseCase.swift
+++ b/iOS/Todo/Todo/Coder/ColumnsUseCase.swift
@@ -30,6 +30,7 @@ struct ColumnsUseCase {
                                     guard let data = data else { return }
                                     guard let response = try? JSONDecoder().decode(ColumnsResponse.self, from: data) else { return }
                                     guard response.status == .success else { return }
+                                    
                                     let column = Columns(columns: response.content.sections)
                                     completed(column)
         }

--- a/iOS/Todo/Todo/Coder/DeleteUseCase.swift
+++ b/iOS/Todo/Todo/Coder/DeleteUseCase.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 struct DeleteUseCase {
-    static func makeDeleteResult(from string: String,
+    static func requestDelete(from string: String,
                                  with manager: NetworkManagable,
                                  result: @escaping (Bool?) -> ()) {
         try? manager.requestResource(from: string, method: .delete, body: nil, format: Format.jsonType,

--- a/iOS/Todo/Todo/Coder/DeleteUseCase.swift
+++ b/iOS/Todo/Todo/Coder/DeleteUseCase.swift
@@ -17,6 +17,7 @@ struct DeleteUseCase {
                                         guard error == nil, let data = data else { return }
                                         guard let cardResponse = try? JSONDecoder().decode(DeleteResponse.self, from: data) else { return }
                                         guard cardResponse.status == .success else { return }
+                                        
                                         result(true)
         }
     }

--- a/iOS/Todo/Todo/Coder/EditedCardViewModelUseCase.swift
+++ b/iOS/Todo/Todo/Coder/EditedCardViewModelUseCase.swift
@@ -18,6 +18,7 @@ struct EditedCardViewModelUseCase {
                 guard error == nil, let data = data else { return }
                 guard let cardResponse = try? JSONDecoder().decode(CardResponse.self, from: data) else { return }
                 guard cardResponse.status == .success else { return }
+                
                 result(CardViewModel(card: cardResponse.content))
         }
     }

--- a/iOS/Todo/Todo/Coder/NewCardViewModelUseCase.swift
+++ b/iOS/Todo/Todo/Coder/NewCardViewModelUseCase.swift
@@ -19,6 +19,7 @@ struct NewCardViewModelUseCase {
                 guard error == nil, let data = data else { return }
                 guard let cardResponse = try? JSONDecoder().decode(CardResponse.self, from: data) else { return }
                 guard cardResponse.status == .success else { return }
+                
                 result(CardViewModel(card: cardResponse.content))
         }
     }

--- a/iOS/Todo/Todo/Models/ColumnTableDataSource.swift
+++ b/iOS/Todo/Todo/Models/ColumnTableDataSource.swift
@@ -52,6 +52,10 @@ final class ColumnTableDataSource: NSObject {
         cardViewModels.remove(at: sourceIndex)
         cardViewModels.insert(cardViewModel, at: destinationIndex)
     }
+    
+    func add(cardViewModel: CardViewModel, at index: Int) {
+        cardViewModels.insert(cardViewModel, at: index)
+    }
 }
 
 extension ColumnTableDataSource: UITableViewDataSource {

--- a/iOS/Todo/Todo/Models/ColumnTableDataSource.swift
+++ b/iOS/Todo/Todo/Models/ColumnTableDataSource.swift
@@ -31,18 +31,26 @@ final class ColumnTableDataSource: NSObject {
         cardViewModels.remove(at: index)
     }
     
-    func append(cardViewModel: CardViewModel) {
-        cardViewModels.append(cardViewModel)
-    }
-    
     func cardViewModel(at index: Int) -> CardViewModel? {
         guard index < cardViewModels.count else { return nil }
         return cardViewModels[index]
     }
     
+    func append(cardViewModel: CardViewModel) {
+        cardViewModels.append(cardViewModel)
+    }
+    
     func update(cardViewModel: CardViewModel, at index: Int) {
         guard index < cardViewModels.count else { return }
         cardViewModels[index] = cardViewModel
+    }
+    
+    func moveCardViewModel(at sourceIndex: Int, to destinationIndex: Int) {
+        guard sourceIndex != destinationIndex else { return }
+        
+        let cardViewModel = cardViewModels[sourceIndex]
+        cardViewModels.remove(at: sourceIndex)
+        cardViewModels.insert(cardViewModel, at: destinationIndex)
     }
 }
 
@@ -63,5 +71,13 @@ extension ColumnTableDataSource: UITableViewDataSource {
             cardCell.contentLabel.text = card?.content
         }
         return cardCell
+    }
+    
+    func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
+    
+    func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        moveCardViewModel(at: sourceIndexPath.row, to: destinationIndexPath.row)
     }
 }

--- a/iOS/Todo/Todo/Models/NewCard.swift
+++ b/iOS/Todo/Todo/Models/NewCard.swift
@@ -12,7 +12,7 @@ struct NewCard: Codable {
     let content: String
     
     func encodeToJSONData() -> Data? {
-        guard let cardData = try? JSONEncoder().encode(self) else { return nil }
-        return cardData
+        guard let newCardData = try? JSONEncoder().encode(self) else { return nil }
+        return newCardData
     }
 }

--- a/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
@@ -143,7 +143,7 @@ extension ColumnViewController: UITableViewDelegate {
             let columnID = columnID,
             let cardID = cardViewModel.cardID else { return }
         let urlString = EndPointFactory.createExistedCardURLString(columnID: columnID, cardID: cardID)
-        DeleteUseCase.makeDeleteResult(from: urlString, with: NetworkManager()) { result in
+        DeleteUseCase.requestDelete(from: urlString, with: NetworkManager()) { result in
             guard let result = result else { return }
             if result {
                 self.columnTableDataSource.removeCardViewModel(at: indexPath.row)

--- a/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
@@ -145,12 +145,7 @@ extension ColumnViewController: UITableViewDelegate {
         let urlString = EndPointFactory.createExistedCardURLString(columnID: columnID, cardID: cardID)
         DeleteUseCase.requestDelete(from: urlString, with: NetworkManager()) { result in
             guard let result = result else { return }
-            if result {
-                self.columnTableDataSource.removeCardViewModel(at: indexPath.row)
-                DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                    tableView.deleteRows(at: [indexPath], with: .fade)
-                }
-            }
+            if result { self.columnTableDataSource.removeCardViewModel(at: indexPath.row) }
         }
     }
 }

--- a/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
@@ -194,7 +194,6 @@ extension ColumnViewController: UITableViewDragDelegate {
 
 extension ColumnViewController: UITableViewDropDelegate {
     func tableView(_ tableView: UITableView, dropSessionDidUpdate session: UIDropSession, withDestinationIndexPath destinationIndexPath: IndexPath?) -> UITableViewDropProposal {
-        // The .move operation is available only for dragging within a single app.
         if tableView.hasActiveDrag {
             if session.items.count > 1 {
                 return UITableViewDropProposal(operation: .cancel)

--- a/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
@@ -8,12 +8,17 @@
 
 import UIKit
 
+protocol ColumnViewControllerDelegate {
+    func columnViewControllerDidMoveToDone(_ cardViewModel: CardViewModel)
+}
+
 final class ColumnViewController: UIViewController {
     //MARK:- internal property
     private let titleView = TitleView()
     private var titleViewModel: TitleViewModel!
     private var columnTable = ColumnTable()
     private var columnTableDataSource: ColumnTableDataSource!
+    var delegate: ColumnViewControllerDelegate?
     var columnID: Int?
     
     override func viewDidLoad() {
@@ -103,8 +108,18 @@ extension ColumnViewController: UITableViewDelegate {
     
     private func moveToDone(_ tableView: UITableView, for indexPath: IndexPath) -> UIAction {
         return UIAction(title: ButtonData.moveToDone) { action in
-            
+            self.moveRowToDone(tableView, for: indexPath)
         }
+    }
+    
+    private func moveRowToDone(_ tableView: UITableView, for indexPath: IndexPath) {
+        guard let cardViewModel = columnTableDataSource.cardViewModel(at: indexPath.row) else { return }
+        delegate?.columnViewControllerDidMoveToDone(cardViewModel)
+        columnTableDataSource.removeCardViewModel(at: indexPath.row)
+    }
+    
+    func receiveToLast(cardViewModel: CardViewModel) {
+        columnTableDataSource.append(cardViewModel: cardViewModel)
     }
     
     private func edit(_ tableView: UITableView, for indexPath: IndexPath) -> UIAction {

--- a/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
@@ -23,9 +23,15 @@ final class ColumnViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureDragAndDrop()
         configureTitleView()
         configureTableView()
         configureObserver()
+    }
+    
+    private func configureDragAndDrop() {
+        columnTable.dragInteractionEnabled = true
+        columnTable.dragDelegate = self
     }
     
     private func configureTitleView() {
@@ -167,6 +173,15 @@ extension ColumnViewController: UITableViewDelegate {
     }
 }
 
+
+extension ColumnViewController: UITableViewDragDelegate {
+    func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath) -> [UIDragItem] {
+        let itemProvider = NSItemProvider()
+        let dragItem = UIDragItem(itemProvider: itemProvider)
+        return [dragItem]
+    }
+}
+
 extension ColumnViewController: PlusButtonDelegate, CardViewControllerDelegate {
     func plusButtonDidTouch() {
         guard let columnID = columnID else { return }
@@ -184,3 +199,5 @@ extension ColumnViewController: PlusButtonDelegate, CardViewControllerDelegate {
         columnTableDataSource.update(cardViewModel: cardViewModel, at: row)
     }
 }
+
+

--- a/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
@@ -96,10 +96,10 @@ extension ColumnViewController: UITableViewDelegate {
     }
     
     private func contextMenu(_ tableView: UITableView, for indexPath: IndexPath) -> UIMenu {
-        return UIMenu(title: "", children: [move(), edit(tableView, for: indexPath), delete(tableView, for: indexPath)])
+        return UIMenu(title: "", children: [moveToDone(), edit(tableView, for: indexPath), delete(tableView, for: indexPath)])
     }
     
-    private func move() -> UIAction {
+    private func moveToDone() -> UIAction {
         return UIAction(title: ButtonData.moveToDone) { action in
             
         }

--- a/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
@@ -143,7 +143,7 @@ extension ColumnViewController: UITableViewDelegate {
             let columnID = columnID,
             let cardID = cardViewModel.cardID else { return }
         let urlString = EndPointFactory.createExistedCardURLString(columnID: columnID, cardID: cardID)
-        DeleteUseCase.requestDelete(from: urlString, with: NetworkManager()) { result in
+        DeleteUseCase.requestDelete(from: urlString, with: MockCardDeleteSuccessStub()) { result in
             guard let result = result else { return }
             if result { self.columnTableDataSource.removeCardViewModel(at: indexPath.row) }
         }

--- a/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/ColumnViewController.swift
@@ -96,10 +96,12 @@ extension ColumnViewController: UITableViewDelegate {
     }
     
     private func contextMenu(_ tableView: UITableView, for indexPath: IndexPath) -> UIMenu {
-        return UIMenu(title: "", children: [moveToDone(), edit(tableView, for: indexPath), delete(tableView, for: indexPath)])
+        return UIMenu(title: "", children: [moveToDone(tableView, for: indexPath),
+                                            edit(tableView, for: indexPath),
+                                            delete(tableView, for: indexPath)])
     }
     
-    private func moveToDone() -> UIAction {
+    private func moveToDone(_ tableView: UITableView, for indexPath: IndexPath) -> UIAction {
         return UIAction(title: ButtonData.moveToDone) { action in
             
         }

--- a/iOS/Todo/Todo/ViewControllers/EditingCardViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/EditingCardViewController.swift
@@ -20,7 +20,7 @@ final class EditingCardViewController: CardViewController {
         guard let cardID = cardViewModel?.cardID, let row = row else { return }
         let urlString = EndPointFactory.createExistedCardURLString(columnID: columnID, cardID: cardID)
         EditedCardViewModelUseCase.makeEditedCardViewModel(from: urlString, cardData: cardData,
-                                                           with: NetworkManager()) { cardViewModel in
+                                                           with: MockCardEditSuccessStub()) { cardViewModel in
                                                             guard let cardViewModel = cardViewModel else { return }
                                                             self.delegate?.cardViewControllerDidCardEdit(cardViewModel,
                                                                                                          row: row)

--- a/iOS/Todo/Todo/ViewControllers/MainViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/MainViewController.swift
@@ -49,9 +49,18 @@ final class MainViewController: UIViewController {
             let controller = ColumnViewController()
             controller.configureTitleViewModel(column: column)
             controller.configureDataSource(column: column)
+            controller.delegate = self
             controller.columnID = column.id
             return controller
         }()
         return columnViewController
+    }
+}
+
+extension MainViewController: ColumnViewControllerDelegate {
+    func columnViewControllerDidMoveToDone(_ cardViewModel: CardViewModel) {
+        let doneIndex = 2
+        guard let doneViewController = children[doneIndex] as? ColumnViewController else { return }
+        doneViewController.receiveToLast(cardViewModel: cardViewModel)
     }
 }

--- a/iOS/Todo/Todo/ViewControllers/MainViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/MainViewController.swift
@@ -61,6 +61,15 @@ extension MainViewController: ColumnViewControllerDelegate {
     func columnViewControllerDidMoveToDone(_ cardViewModel: CardViewModel) {
         let doneIndex = 2
         guard let doneViewController = children[doneIndex] as? ColumnViewController else { return }
-        doneViewController.receiveToLast(cardViewModel: cardViewModel)
+        doneViewController.addToLast(cardViewModel: cardViewModel)
+    }
+    
+    func columnViewControllerDidMove(sourceColumnID: Int, sourceRow: Int) {
+        children.forEach { viewController in
+            guard let columnViewController = viewController as? ColumnViewController,
+                let columnID = columnViewController.columnID,
+                columnID == sourceColumnID else { return }
+            columnViewController.removeCardViewModel(row: sourceRow)
+        }
     }
 }

--- a/iOS/Todo/Todo/ViewControllers/MainViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/MainViewController.swift
@@ -26,7 +26,7 @@ final class MainViewController: UIViewController {
     }
     
     private func configureColumnsCase() {
-        ColumnsUseCase.makeColumns(with: NetworkManager()) { columnsDataSource in
+        ColumnsUseCase.makeColumns(with: MockColumnsSuccessStub()) { columnsDataSource in
             columnsDataSource?.iterateColumns(with: { column in
                 self.addColumnViewController(column: column)
             })

--- a/iOS/Todo/Todo/ViewControllers/NewCardViewController.swift
+++ b/iOS/Todo/Todo/ViewControllers/NewCardViewController.swift
@@ -18,7 +18,7 @@ final class NewCardViewController: CardViewController {
         guard let columnID = columnID else { return }
         guard let cardData = generateNewCard().encodeToJSONData() else { return }
         NewCardViewModelUseCase.makeNewCardViewModel(from: EndPointFactory.createNewCardURLString(columnID: columnID),
-                                                     cardData: cardData, with: NetworkManager()) { cardViewModel in
+                                                     cardData: cardData, with: MockCardCreateSuccessStub()) { cardViewModel in
                                                         guard let cardViewModel = cardViewModel else { return }
                                                         self.delegate?.cardViewControllerDidCardCreate(cardViewModel)
         }

--- a/iOS/Todo/TodoTests/DragObject.swift
+++ b/iOS/Todo/TodoTests/DragObject.swift
@@ -1,0 +1,15 @@
+//
+//  DraggedCard.swift
+//  Todo
+//
+//  Created by kimdo2297 on 2020/04/15.
+//  Copyright © 2020 Jason. All rights reserved.
+//
+
+import Foundation
+
+struct DragObject {
+    let cardViewModel: CardViewModel
+    let columnID: Int
+    let row: Int
+}


### PR DESCRIPTION
#91 을 해결하였습니다. 

* 네트워크 연동은 하지 않았습니다. 이는 API 구현되면 하려고 합니다.

> moveToDone 기능 구현

특정 카드의 contextMenu에서 moveToDone 버튼을 누르면, 
1. 부모인 `MainViewController`에게 해당 카드 뷰모델을 넘깁니다. 
2. `MainViewController`는 done인 컬럼 뷰컨트롤러에게 카드 뷰모델을 넘겨 테이블의 마지막 행에 추가합니다. 
3. 기존 컬럼 뷰컨트롤러의 카드 뷰모델은 테이블에서 삭제하는 식으로 구현하였습니다.

> 드래그 앤 드랍

* 테이블뷰의 dragInteractionEnabled를 true로 할당해서 드래그 인터렉션이 가능하도록 하였습니다.
* 테이블 뷰의 dragDelegate 역할을 테이블 뷰를 가지고 있는 컬럼 뷰컨트롤러가 하도록 하여 드래그 되고 있는 아이템들`[UIDragItem]` 을 전달하도록 하였습니다. 

* 기존의 테이블의 다른 행으로 카드를 옮기는 기능 구현 
  * UITableDataSource의 `tableView(_:canMoveRowAt:)`와 `tableView(_:moveRowAt:to:)`를 이용해 같은 행에서 카드가 옮겨질수 있도록 하였습니다.

* 다른 테이블로 카드를 옮기는 기능 구현
  *  컬럼 뷰컨트롤러가 dragDelegate의 역할을 하도록 하여 
  `tableView(_:dropSessionDidUpdate:withDestinationIndexPath:)`을 이용해 외부에서 drop된 카드를 자신의 테이블에 옮겨질 수 있도록 하였고, 다시 `MainViewController`에게 메시지를 전달해 카드가 원래 있었던 기존의 테이블에서는 카드가 삭제되도록 하였습니다.


