### PR TITLE
[BE][#125] feat: 카드 삭제 soft delete로 변경

### DIFF
--- a/BE/src/main/java/com/codesquad/team10/todo/entity/Card.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/entity/Card.java
@@ -88,6 +88,10 @@ public class Card {
         return deleted;
     }
 
+    public void setDeleted(boolean deleted) {
+        this.deleted = deleted;
+    }
+
     public Integer getUser() {
         return user;
     }

--- a/BE/src/main/java/com/codesquad/team10/todo/entity/Section.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/entity/Section.java
@@ -83,7 +83,7 @@ public class Section {
         if (!target.equals(deleteCard))
             throw new UnmatchedRequestDataException();
 
-        cards.remove(target);
+        target.setDeleted(true);
     }
 
     @Override


### PR DESCRIPTION
Closed #125 
- 카드 삭제 시, 해당 카드의 delete 컬럼 값을 true로 변경하며, 물리적으로 DB에서 삭제하진 않습니다.
- 전체 보드 데이터 요청 시, delete=true인 카드들은 출력하지 않습니다.
- 카드 관련 이벤트 응답 데이터의 card_count에도 delete=true인 카드들은 포함시키지 않습니다.