### PR TITLE
[BE][#161] fix: Access-Control-Expose-Headers 헤더로 Authorization 헤더 접근 옵션 지정

### DIFF
--- a/BE/src/main/java/com/codesquad/team10/todo/config/SimpleCorsFilter.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/config/SimpleCorsFilter.java
@@ -23,6 +23,7 @@ public class SimpleCorsFilter implements Filter {
         HttpServletResponse response = (HttpServletResponse) res;
         response.setHeader("Access-Control-Allow-Origin", request.getHeader("Origin"));
         response.setHeader("Access-Control-Allow-Credentials", "true");
+        response.setHeader("Access-Control-Expose-Headers", "*, Authorization");
         response.setHeader("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, X-Requested-With, Authorization, Access-Control-Request-Method, Access-Control-Request-Headers");
         response.setHeader("Access-Control-Max-Age", "3600");
         response.setHeader("Access-Control-Allow-Methods", "POST, GET, HEAD, OPTIONS, DELETE, PUT, PATCH");


### PR DESCRIPTION
- Closed #161
- Authorization은 * 에 포함되지 않으므로 별도로 지정해야 함 (테스트 필요)