### PR TITLE
[BE][#181] feat: 섹션 삭제 api 구현

### DIFF
--- a/BE/README.md
+++ b/BE/README.md
@@ -420,6 +420,25 @@ http://ec2-15-164-63-83.ap-northeast-2.compute.amazonaws.com:8080
 }
 ```
 
+## 섹션 삭제 요청
+
+#### DELETE `/board/section/{sectionId}`
+
+### 요청 데이터
+- 로그인하고 발급받은 토큰을 Authorization 헤더에 넣어서 요청 해주세요.
+
+### JSON 응답
+- 성공적으로 반환하는 경우
+   - 상태 코드 : OK (200)
+```
+{
+    "status": "SUCCESS",
+    "content": {
+        "log_id": 4
+    }
+}
+```
+
 ## 전체 로그 요청
 
 #### GET `/board/logs`

--- a/BE/src/main/java/com/codesquad/team10/todo/api/SectionController.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/api/SectionController.java
@@ -13,10 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -48,6 +45,16 @@ public class SectionController {
         sectionRepository.save(section);
         SectionDTO sectionDTO = (SectionDTO) ModelMapper.of(sectionRepository.findById(section.getId()).orElseThrow(ResourceNotFoundException::new));
         Map<String, Object> responseData = logService.getResponseDataWithLog(Action.ADDED, sectionDTO, loginUser);
+        return new ResponseEntity<>(new ResponseData(ResponseData.Status.SUCCESS, responseData), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{sectionId}")
+    public ResponseEntity<ResponseData> delete(@PathVariable int sectionId,
+                                               HttpServletRequest request) {
+        User loginUser = (User)request.getAttribute("user");
+        Section section = sectionRepository.findById(sectionId).orElseThrow(ResourceNotFoundException::new);
+        sectionRepository.delete(section);
+        Map<String, Object> responseData = logService.getResponseDataWithLog(Action.REMOVED, (SectionDTO) ModelMapper.of(section), loginUser);
         return new ResponseEntity<>(new ResponseData(ResponseData.Status.SUCCESS, responseData), HttpStatus.OK);
     }
 }

--- a/BE/src/main/java/com/codesquad/team10/todo/service/LogService.java
+++ b/BE/src/main/java/com/codesquad/team10/todo/service/LogService.java
@@ -33,11 +33,17 @@ public class LogService {
         return logRepository.findById(logId).orElseThrow(ResourceNotFoundException::new);
     }
 
-    // 섹션 추가 로그
+    // 섹션 추가, 삭제 로그
     public Map<String, Object> getResponseDataWithLog(Action action, SectionDTO section, User user) {
         Log log = new Log(user.getName(), action, Target.SECTION, section.getTitle(), null, null, null, user.getBoard());
         logRepository.save(log);
-        return constructResonseData(section, log);
+        switch (action) {
+            case ADDED:
+                return constructResonseData(section, log);
+            case REMOVED:
+                return constructResonseData(log);
+        }
+        return null;
     }
 
     // 카드 추가, 수정 로그
@@ -108,6 +114,12 @@ public class LogService {
     private Map<String, Object> constructResonseData(SectionDTO sectionDTO, Log log) {
         Map<String, Object> map = new HashMap<>();
         map.put("section", sectionDTO);
+        map.put("log_id", log.getId());
+        return map;
+    }
+
+    private Map<String, Object> constructResonseData(Log log) {
+        Map<String, Object> map = new HashMap<>();
         map.put("log_id", log.getId());
         return map;
     }


### PR DESCRIPTION
Closed #181
- 클라이언트로부터 전달받은 섹션 아이디에 해당되는 섹션을 DB에서 제거합니다.
- 해당 섹션이 제거되면 섹션에 포함된 카드 객체도 모두 삭제됩니다.
- 응답 데이터는 섹션 제거에 대한 로그 아이디만 전달됩니다.
- 자세한 것은 README를 참고해주세요.